### PR TITLE
Respect JsonPropertyName attribute during serialization\deserialization

### DIFF
--- a/Source/Json.Abstraction/Converters/AbstractionConverter.cs
+++ b/Source/Json.Abstraction/Converters/AbstractionConverter.cs
@@ -39,7 +39,15 @@ public class AbstractionConverter<TAbstraction> : ConverterBase<TAbstraction>
             .Where(x => !Attribute.IsDefined(x, typeof(JsonIgnoreAttribute)))
             .ToList().ForEach(property =>
         {
-            var propertyJsonName = ConvertPropertyName(options, property.Name);
+            string propertyJsonName = string.Empty;
+            if (Attribute.GetCustomAttribute(property, typeof(JsonPropertyNameAttribute), true) is JsonPropertyNameAttribute attr)
+            {
+                propertyJsonName = attr.Name;
+            }
+            else
+            {
+                propertyJsonName = ConvertPropertyName(options, property.Name);
+            }
             var propertyValue = value.GetType().GetProperty(property.Name)?.GetValue(value);
 
             if (propertyValue != null || !options.IgnoreNullValues)
@@ -71,7 +79,15 @@ public class AbstractionConverter<TAbstraction> : ConverterBase<TAbstraction>
             .Where(x => !Attribute.IsDefined(x, typeof(JsonIgnoreAttribute)))
             .ToList().ForEach(property =>
         {
-            var jsonPropertyName = ConvertPropertyName(options, property.Name);
+            string jsonPropertyName = string.Empty;
+            if (Attribute.GetCustomAttribute(property, typeof(JsonPropertyNameAttribute), true) is JsonPropertyNameAttribute attr)
+            {
+                jsonPropertyName = attr.Name;
+            }
+            else
+            {
+                jsonPropertyName = ConvertPropertyName(options, property.Name);
+            }
             if (jsonElement.TryGetProperty(jsonPropertyName, out var jsonProperty))
             {
                 try

--- a/Source/Json.Abstraction/Converters/InterfaceConverter.cs
+++ b/Source/Json.Abstraction/Converters/InterfaceConverter.cs
@@ -25,7 +25,15 @@ namespace Json.Abstraction.Converters
                 .Where(x => !Attribute.IsDefined(x, typeof(JsonIgnoreAttribute)))
                 .ToList().ForEach(property =>
             {
-                var propertyJsonName = ConvertPropertyName(options, property.Name);
+                string propertyJsonName = string.Empty;
+                if (Attribute.GetCustomAttribute(property, typeof(JsonPropertyNameAttribute), true) is JsonPropertyNameAttribute attr)
+                {
+                    propertyJsonName = attr.Name;
+                }
+                else
+                {
+                    propertyJsonName = ConvertPropertyName(options, property.Name);
+                }
                 var propertyValue = value.GetType().GetProperty(property.Name)?.GetValue(value);
 
                 if (propertyValue != null || !options.IgnoreNullValues)

--- a/Test/Json.Abstraction.Tests/AbstractionConverterTests.cs
+++ b/Test/Json.Abstraction.Tests/AbstractionConverterTests.cs
@@ -24,6 +24,21 @@ namespace Json.Abstraction.Tests
         }
 
         [Test]
+        public void AbstractionDeserialize_ListOfStringsWithPropertyName()
+        {
+            var mock = AbstractionMocks.GetListOfStringsWithPropertyNameMock();
+
+            var result = DeserializeJson<ListOfStringsWithPropertyName>(mock.JsonData, mock.AbstractType);
+
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<ListOfStringsWithPropertyName>(result, "Wrong instance");
+            Assert.AreEqual("Test", result.Param1);
+            Assert.IsTrue(result.Collection.Count == 2);
+            Assert.AreEqual("opt1", result.Collection[0]);
+            Assert.AreEqual("opt2", result.Collection[1]);
+        }
+
+        [Test]
         public void AbstractionDeserialize_ArrayOfStrings()
         {
             var mock = AbstractionMocks.GetArrayOfStringsMock();
@@ -122,6 +137,17 @@ namespace Json.Abstraction.Tests
         public void AbstractionSerialize_ListOfStrings()
         {
             var mock = AbstractionMocks.GetListOfStringsMock();
+
+            var result = SerializeJson(mock.TestObject, mock.AbstractType);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(GetNormalizedJson(mock.JsonData), result);
+        }
+
+        [Test]
+        public void AbstractionSerialize_ListOfStringsWithPropertyName()
+        {
+            var mock = AbstractionMocks.GetListOfStringsWithPropertyNameMock();
 
             var result = SerializeJson(mock.TestObject, mock.AbstractType);
 

--- a/Test/Json.Abstraction.Tests/InterfaceConverterTests.cs
+++ b/Test/Json.Abstraction.Tests/InterfaceConverterTests.cs
@@ -24,6 +24,21 @@ namespace Json.Abstraction.Tests
         }
 
         [Test]
+        public void InterfaceDeserialize_ResourceWithPropertyNameAttr()
+        {
+            var mock = ObjectMocks.GetResourceWithPropertyNameAttrMock();
+
+            var result = DeserializeJson<ResourceWithPropertyNameAttr>(mock.JsonData, mock.typeToConvert);
+
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<ResourceWithPropertyNameAttr>(result, "Wrong instance");
+            Assert.AreEqual(3, result.Param1);
+            Assert.AreEqual(5, result.Param2);
+            Assert.IsInstanceOf<Nested>(result.NestedObject, "Wrong instance");
+            Assert.AreEqual("Test", result.NestedObject.Param2);
+        }
+
+        [Test]
         public void InterfaceDeserialize_ObjectWithNestedObject()
         {
             var mock = ObjectMocks.GetObjectWithNestedObjectMock();
@@ -144,6 +159,18 @@ namespace Json.Abstraction.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(GetNormalizedJson(mock.JsonData), result);
         }
+
+        [Test]
+        public void InterfaceSerialize_ResourceWithPropertyNameAttr()
+        {
+            var mock = ObjectMocks.GetResourceWithPropertyNameAttrMock();
+
+            var result = SerializeJson(mock.TestObject, mock.typeToConvert);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(GetNormalizedJson(mock.JsonData), result);
+        }
+
 
         [Test]
         public void InterfaceSerialize_ObjectWithNestedObject()

--- a/Test/Json.Abstraction.Tests/Mocks/AbstractionMocks.cs
+++ b/Test/Json.Abstraction.Tests/Mocks/AbstractionMocks.cs
@@ -30,6 +30,29 @@ namespace Json.Abstraction.Tests.Mocks
                 typeof(CollectionObjectsAbstraction));
         }
 
+        public static (string JsonData, object TestObject, Type AbstractType) GetListOfStringsWithPropertyNameMock()
+        {
+            return (
+                @"{
+                    ""_t"": ""ListOfStringsWithPropertyName"",
+                    ""col"": [
+                        ""opt1"",
+                        ""opt2""
+                    ],
+                    ""param1"": ""Test""
+                }",
+                new ListOfStringsWithPropertyName
+                {
+                    Param1 = "Test",
+                    Collection = new List<string>
+                    {
+                        "opt1",
+                        "opt2"
+                    }
+                },
+                typeof(CollectionObjectsAbstraction));
+        }
+
         public static (string JsonData, object TestObject, Type AbstractType) GetArrayOfStringsMock()
         {
             return (

--- a/Test/Json.Abstraction.Tests/Mocks/Models/Abstraction/AbstractionModels.cs
+++ b/Test/Json.Abstraction.Tests/Mocks/Models/Abstraction/AbstractionModels.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Json.Abstraction.Tests.Mocks.Models.Abstraction
 {
@@ -19,6 +20,12 @@ namespace Json.Abstraction.Tests.Mocks.Models.Abstraction
     public abstract class CollectionObjectsAbstraction
     {
         public string Param1 { get; set; }
+    }
+
+    public class ListOfStringsWithPropertyName : CollectionObjectsAbstraction
+    {
+        [JsonPropertyName("col")]
+        public List<string> Collection { get; set; }
     }
 
     public class ListOfStrings : CollectionObjectsAbstraction

--- a/Test/Json.Abstraction.Tests/Mocks/Models/Objects/ObjectsModels.cs
+++ b/Test/Json.Abstraction.Tests/Mocks/Models/Objects/ObjectsModels.cs
@@ -1,4 +1,6 @@
-﻿namespace Json.Abstraction.Tests.Mocks.Models.Objects
+﻿using System.Text.Json.Serialization;
+
+namespace Json.Abstraction.Tests.Mocks.Models.Objects
 {
     public interface INested
     {
@@ -15,6 +17,15 @@
     public class ResourceWithObject
     {
         public int Param1 { get; set; }
+        public INested NestedObject { get; set; }
+    }
+
+    public class ResourceWithPropertyNameAttr
+    {
+        public int Param1 { get; set; }
+        [JsonPropertyName("param_2")]
+        public int Param2 { get; set; }
+        [JsonPropertyName("nested")]
         public INested NestedObject { get; set; }
     }
 }

--- a/Test/Json.Abstraction.Tests/Mocks/ObjectMocks.cs
+++ b/Test/Json.Abstraction.Tests/Mocks/ObjectMocks.cs
@@ -23,6 +23,25 @@ namespace Json.Abstraction.Tests.Mocks
                 typeof(ResourceWithObject));
         }
 
+        public static (string JsonData, object TestObject, Type typeToConvert) GetResourceWithPropertyNameAttrMock()
+        {
+            return (
+                @"{
+                    ""param1"": 3,
+                    ""param_2"": 5,
+                    ""nested"": {
+                        ""param2"": ""Test""
+                    }
+                }",
+                new ResourceWithPropertyNameAttr
+                {
+                    Param1 = 3,
+                    Param2 = 5,
+                    NestedObject = new Nested { Param2 = "Test" }
+                },
+                typeof(ResourceWithPropertyNameAttr));
+        }
+
         public static (string JsonData, object TestObject, Type typeToConvert) GetObjectWithNestedObjectMock()
         {
             return (


### PR DESCRIPTION
At the moment Json.Abstraction ignores JsonPropertyName attribute.